### PR TITLE
Update Polyglot to 25.0.2, use StatementTag, add example for Python

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <version>${graalvm.version}</version>
     <name>simpletool</name>
     <properties>
-        <graalvm.version>23.1.0</graalvm.version>
+        <graalvm.version>25.0.2</graalvm.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
@@ -85,9 +85,17 @@
         </dependency>
         <!-- needed to run tests -->
         <dependency>
-            <groupId>org.graalvm.js</groupId>
-            <artifactId>js-language</artifactId>
+            <groupId>org.graalvm.polyglot</groupId>
+            <artifactId>js</artifactId>
             <version>${graalvm.version}</version>
+            <scope>runtime</scope>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.polyglot</groupId>
+            <artifactId>python</artifactId>
+            <version>${graalvm.version}</version>
+            <type>pom</type>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/oracle/truffle/st/SimpleCoverageInstrument.java
+++ b/src/main/java/com/oracle/truffle/st/SimpleCoverageInstrument.java
@@ -56,7 +56,7 @@ import org.graalvm.options.OptionValues;
 import com.oracle.truffle.api.Option;
 import com.oracle.truffle.api.instrumentation.Instrumenter;
 import com.oracle.truffle.api.instrumentation.SourceSectionFilter;
-import com.oracle.truffle.api.instrumentation.StandardTags.ExpressionTag;
+import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.instrumentation.TruffleInstrument;
 import com.oracle.truffle.api.instrumentation.TruffleInstrument.Registration;
 import com.oracle.truffle.api.nodes.Node;
@@ -167,7 +167,7 @@ public final class SimpleCoverageInstrument extends TruffleInstrument {
      * @param env The environment, used to get the {@link Instrumenter}
      */
     private void enable(final Env env) {
-        SourceSectionFilter filter = SourceSectionFilter.newBuilder().tagIs(ExpressionTag.class).includeInternal(false).build();
+        SourceSectionFilter filter = SourceSectionFilter.newBuilder().tagIs(StatementTag.class).includeInternal(false).build();
         Instrumenter instrumenter = env.getInstrumenter();
         instrumenter.attachLoadSourceSectionListener(filter, new GatherSourceSectionsListener(this), true);
         instrumenter.attachExecutionEventFactory(filter, new CoverageEventFactory(this));


### PR DESCRIPTION
- Upgrade project dependencies for Polyglot to version 25.0.2
- Trace coverage of StatementTag tagged nodes, not ExpressionTag
- Add a Python example to demonstrate usage